### PR TITLE
Modify Android CI workflow for macOS 26 and Gradle caching

### DIFF
--- a/.github/workflows/android-dev.yml
+++ b/.github/workflows/android-dev.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # macos-14:     CPU: (3) arm64 Apple M1 (Virtual);            Memory: 89.83 MB / 7.00 GB
+        # macos-26:     CPU: (3) arm64 Apple M1 (Virtual);            Memory: 89.83 MB / 7.00 GB
         # ubuntu-24.04: CPU: (4) x64 AMD EPYC 7763 64-Core Processor; Memory: 14.56 GB / 15.62 GB
-        os: [ ubuntu-24.04 ] # M1 not a really faster than x64
+        os: [ macos-26, ubuntu-24.04 ] # M1 not a really faster than x64
         ruby: [ '3.4.2']
         java: [ '21' ]
 
@@ -126,6 +126,16 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'zulu'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: Install Ruby ${{ matrix.ruby }}
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
Updated the workflow to include macOS 26 and added caching for Gradle packages.